### PR TITLE
feat: add plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ npm install next-remote-refresh --save-dev
 
 [View Example](/example)
 
-```json
-{
-  "scripts": {
-    "dev": "next-remote-refresh ../docs & next dev"
-  }
-}
+### Plugin
+
+```js
+// next.config.js
+const withRemoteRefresh = require('next-remote-refresh')({
+  paths: ['files', 'to', 'watch'],
+  port: 3001, // port for web socket server
+  ignored: '**/*.json', // files to skip
+})
+module.exports = withRemoteRefresh({
+  // next config options here
+})
 ```
 
 ### `useRemoteRefresh`
@@ -33,7 +39,8 @@ import path from 'path'
 function App({ name, version }) {
   useRemoteRefresh({
     shouldRefresh: (path, router) => {
-      // do something based on changed file path
+      // control when the page should refresh
+      return true
     },
   })
   return (

--- a/bin/next-remote-refresh.js
+++ b/bin/next-remote-refresh.js
@@ -1,40 +1,14 @@
 #!/usr/bin/env node
 
-const express = require('express')
-const http = require('http')
-const path = require('path')
-const WebSocket = require('ws')
-const chokidar = require('chokidar')
+const { createServer } = require('../server')
 
 const [paths, ...options] = process.argv.slice(2)
 const port = options.find((option) => option.includes('port'))
-const ignore = options.find((option) => option.includes('ignore'))
+const ignored = options.find((option) => option.includes('ignore'))
 const parseOption = (option) => (option ? option.split('=')[1] : null)
 
-const app = express()
-const server = http.createServer(app)
-const wss = new WebSocket.Server({ server })
-let sockets = []
-
-wss.on('connection', (ws) => {
-  sockets.push(ws)
-  ws.on('close', () => {
-    sockets = sockets.filter((socket) => socket !== ws)
-  })
+createServer({
+  paths,
+  port: parseInt(parseOption(port)) || 3001,
+  ignored: parseOption(ignored),
 })
-
-server.listen(parseInt(parseOption(port)) || 3001)
-
-chokidar
-  .watch(
-    (Array.isArray(paths) ? paths : [paths]).map((filePath) =>
-      path.resolve(process.cwd(), filePath)
-    ),
-    { ignored: parseOption(ignore) }
-  )
-  .on('change', (filePath) => {
-    const baseName = path.basename(path.dirname(process.cwd()))
-    const updatedPath = `${baseName}${filePath.split(baseName)[1]}`
-    console.log(`${path.basename(filePath)} updated`)
-    sockets.map((socket) => socket.send(updatedPath))
-  })

--- a/example/next.config.js
+++ b/example/next.config.js
@@ -1,0 +1,5 @@
+const withRemoteRefresh = require('next-remote-refresh')({
+  paths: './package.json',
+  port: 4001,
+})
+module.exports = withRemoteRefresh()

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": "true",
   "scripts": {
-    "dev": "node ../bin/next-remote-refresh ../package.json --port=3002 & next dev"
+    "dev": "next dev"
   },
   "dependencies": {
     "next": "^11.0.1"

--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -1,11 +1,7 @@
 import path from 'path'
 import fs from 'fs'
-import { useRemoteRefresh } from 'next-remote-refresh'
 
 export default function Index({ name, version, description }) {
-  useRemoteRefresh({
-    port: 3002,
-  })
   return (
     <div>
       <h2>

--- a/hook.js
+++ b/hook.js
@@ -1,0 +1,26 @@
+const { useEffect } = require('react')
+const { useRouter } = require('next/router')
+
+module.exports.useRemoteRefresh = function ({
+  port = 3001,
+  shouldRefresh = (data, router) => true,
+} = {}) {
+  if (process.env.NODE_ENV === 'development') {
+    const router = useRouter()
+    const refreshData = () => {
+      const scrollY = window.pageYOffset
+      router.replace(router.asPath).then(() => {
+        window.scrollTo(0, scrollY)
+      })
+    }
+    useEffect(() => {
+      const ws = new WebSocket(`ws://localhost:${port}/ws`)
+      ws.onmessage = (event) => {
+        if (shouldRefresh(event.data, router)) {
+          refreshData()
+        }
+      }
+      return () => ws.close()
+    }, [])
+  }
+}

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,7 @@
+module.exports = async function (source) {
+  const callback = this.async()
+  if (this.resourcePath.includes('_app')) {
+    // insert hook here
+  }
+  return callback(null, source)
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "files": [
     "bin",
-    "hook.js"
+    "hook.js",
+    "index.js",
+    "loader.js",
+    "server.js"
   ],
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const express = require('express')
+const http = require('http')
+const path = require('path')
+const WebSocket = require('ws')
+const chokidar = require('chokidar')
+
+module.exports.createServer = function ({ paths = '.', port = 3001, ignored }) {
+  const app = express()
+  const server = http.createServer(app)
+  const wss = new WebSocket.Server({ server })
+  let sockets = []
+
+  wss.on('connection', (ws) => {
+    sockets.push(ws)
+    ws.on('close', () => {
+      sockets = sockets.filter((socket) => socket !== ws)
+    })
+  })
+
+  server.listen(port)
+
+  chokidar
+    .watch(
+      (Array.isArray(paths) ? paths : [paths]).map((filePath) =>
+        path.resolve(process.cwd(), filePath)
+      ),
+      { ignored }
+    )
+    .on('change', (filePath) => {
+      const baseName = path.basename(path.dirname(process.cwd()))
+      const updatedPath = `${baseName}${filePath.split(baseName)[1]}`
+      console.log(`${path.basename(filePath)} updated`)
+      sockets.map((socket) => socket.send(updatedPath))
+    })
+}


### PR DESCRIPTION
Trying to figure out a way to make setup easier by creating a plugin, ideally we can just do this:

```js
const withRemoteRefresh = require('next-remote-refresh')({
  paths: ['path', 'to', 'files'],
  port: 4001,
})
module.exports = withRemoteRefresh()
```

Not sure this is viable though? Guessing that creating an additional server as a side-effect isn't a good idea 😅 