### PR TITLE
fix missing hook module in 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.js",
   "files": [
-    "plugin.js",
+    "hook.js",
     "server.js"
   ],
   "repository": {


### PR DESCRIPTION
regression from 410106f43346f3da992858ca2fb94ec726c12c35