### PR TITLE
Fix refreshing on pages with a hash in URL

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -33,10 +33,12 @@ module.exports.useRemoteRefresh = function ({
   }
 }
 
+const QUERY_NAME = '__remote-refresh__'
+
 async function replace(router: NextRouter, refresh: string | null) {
   const query = { ...router.query }
-  if (!refresh) delete query.refresh
-  else query.refresh = refresh
+  if (!refresh) delete query[QUERY_NAME]
+  else query[QUERY_NAME] = refresh
 
   return router.replace(
     {

--- a/hook.js
+++ b/hook.js
@@ -1,5 +1,5 @@
 const { useEffect } = require('react')
-const { useRouter } = require('next/router')
+const { useRouter, NextRouter } = require('next/router')
 const getConfig = require('next/config').default
 
 // private API, might break on the next version
@@ -21,14 +21,30 @@ module.exports.useRemoteRefresh = function ({
         if (event.data === '\uD83D\uDC93') {
           return
         }
-        
+
         if (shouldRefresh(JSON.parse(event.data).path)) {
-          router.replace(router.asPath, router.asPath, {
-            scroll: false,
-          })
+          // Change a query parameter on every refresh to forcefully refresh the props
+          // otherwise, pages with a hash like `/blog#my-heading` will not refresh
+          replace(router, '1').then(() => replace(router, null))
         }
       })
       return () => source.close()
     }, [router])
   }
+}
+
+async function replace(router: NextRouter, refresh: string | null) {
+  const query = { ...router.query }
+  if (!refresh) delete query.refresh
+  else query.refresh = refresh
+
+  return router.replace(
+    {
+      pathname: router.pathname,
+      hash: window.location.hash,
+      query
+    },
+    undefined,
+    { scroll: false, shallow: false },
+  )
 }


### PR DESCRIPTION
I noticed that on pages with a hash in the URL, the `router.replace` was not actually re-running data fetching methods. My solution is to add and remove a query parameter on every refresh instead, but it feels pretty hacky. (we should fix this at the Next.js core level, I raised it with the team)