### PR TITLE
auto add useRemoteRefresh hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const createServer = require('./server')
 
 let port
@@ -13,6 +14,14 @@ module.exports = function plugin(options) {
         ...nextConfig.publicRuntimeConfig,
         __remoteRefreshPath: `http://localhost:${port}/refresh`,
       }
+    }
+
+    nextConfig.webpack = (config) => {
+      config.module.rules.unshift({
+        test: /_app.*(js|jsx|ts|tsx)$/,
+        use: [{ loader: path.resolve(__dirname, 'loader') }],
+      })
+      return config
     }
 
     return nextConfig

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,10 @@
+const remoteRefreshExport = `
+function RemoteRefresh(props) {
+    return _react["default"].createElement(App, Object.assign({}, props, { children: 'Hello World' }));
+};
+exports.default = RemoteRefresh;
+`
+
+module.exports = function (source) {
+  return source.replace('exports.default = App;', remoteRefreshExport)
+}


### PR DESCRIPTION
Just the start of this PR, not sure if it's viable or not. The current state of this is grabbing the wrong `_app` file. I don't know enough about NextJS internals for this, but thinking we can detect if an `_app` file is present and inject the hook or construct our own `_app` wrapper. An AST transform is probably better here, but wanted minimal performance impact if possible. 

closes #6