### PR TITLE
better port variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 .next
 node_modules

--- a/hook.js
+++ b/hook.js
@@ -1,15 +1,15 @@
 const { useEffect } = require('react')
 const { useRouter } = require('next/router')
-const getConfig = require('next/config').default
 
 module.exports.useRemoteRefresh = function ({
   shouldRefresh = (updatedPath) => true,
 } = {}) {
   if (process.env.NODE_ENV !== 'production') {
-    const port = getConfig().publicRuntimeConfig.__remoteRefreshPort
     const router = useRouter()
     useEffect(() => {
-      const ws = new WebSocket(`ws://localhost:${port}/ws`)
+      const ws = new WebSocket(
+        `ws://localhost:${process.env.remoteRefreshPort}/ws`
+      )
       ws.onmessage = (event) => {
         if (shouldRefresh(event.data)) {
           router.replace(router.asPath)

--- a/index.js
+++ b/index.js
@@ -1,18 +1,19 @@
 const createServer = require('./server')
 
-let port
-
 module.exports = function plugin(options) {
+  let port
+
   return function withConfig(nextConfig = {}) {
     if (process.env.NODE_ENV !== 'production') {
       if (!port) {
         port = createServer(options)
       }
 
-      nextConfig.publicRuntimeConfig = {
-        ...nextConfig.publicRuntimeConfig,
-        __remoteRefreshPort: port,
+      if (nextConfig.env === undefined) {
+        nextConfig.env = {}
       }
+
+      nextConfig.env.remoteRefreshPort = port
     }
 
     return nextConfig

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,7 +3,7 @@ import { NextConfig } from 'next/dist/next-server/server/config-shared'
 declare module 'next-remote-refresh' {
   interface Options {
     paths: string[]
-    ignored: string
+    ignored?: string
   }
 
   type Config = NextConfig | {}


### PR DESCRIPTION
For some reason `getConfig` started returning `undefined` in Next 12.0.7. This fixes that by removing `next/config` in favor of a more simplified environment variable.