### PR TITLE
Fix optional shouldRefresh hook param

### DIFF
--- a/hook.d.ts
+++ b/hook.d.ts
@@ -1,5 +1,5 @@
 interface HookOptions {
-  shouldRefresh?: (updatedPath: string) => boolean
+  shouldRefresh?: (updatedPath: string, currentPath: string) => boolean
 }
 
 export function useRemoteRefresh(options?: HookOptions): void

--- a/hook.js
+++ b/hook.js
@@ -1,5 +1,5 @@
-const { useEffect } = require('react')
-const { useRef, useRouter } = require('next/router')
+const { useEffect, useRef } = require('react')
+const { useRouter } = require('next/router')
 
 module.exports.useRemoteRefresh = function ({ shouldRefresh } = {}) {
   if (process.env.NODE_ENV !== 'production') {
@@ -11,7 +11,7 @@ module.exports.useRemoteRefresh = function ({ shouldRefresh } = {}) {
       return () => ws.close()
     }, [])
     useEffect(() => {
-      const ws = ws.current
+      const ws = wsRef.current
       const listener = (event) => {
         if (!shouldRefresh || shouldRefresh(event.data)) {
           router.replace(router.asPath)

--- a/hook.js
+++ b/hook.js
@@ -13,12 +13,12 @@ module.exports.useRemoteRefresh = function ({ shouldRefresh } = {}) {
     useEffect(() => {
       const ws = ws.current
       const listener = (event) => {
-        if (shouldRefresh(event.data)) {
+        if (!shouldRefresh || shouldRefresh(event.data)) {
           router.replace(router.asPath)
         }
       }
       ws.addEventListener('message', listener)
       return () => ws.removeEventListener('message', listener)
-    }, [router.asPath])
+    }, [shouldRefresh, router.asPath])
   }
 }


### PR DESCRIPTION
I missed this while refactoring the hook in the last PR. I'm avoiding assigning a default value in the hook's arguments since it would case the `useEffect` to run every render.