### PR TITLE
Fix port number in entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ module.exports = function plugin(options) {
 
   return function withConfig(nextConfig = {}) {
     if (process.env.NODE_ENV !== 'production') {
-      if (!port) {
-        port = createServer(options)
+      if (port === undefined) {
+        ({ port } = createServer(options).address())
       }
 
       if (nextConfig.env === undefined) {

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,42 @@
+const createServer = require('./server')
+const plugin = require('.')
+
+jest.mock('./server')
+
+describe('plugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sets remoteRefreshPort in the env', async () => {
+    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    const withRemoteRefresh = plugin({ paths: '/test' })
+
+    const config = withRemoteRefresh()
+
+    expect(createServer).toHaveBeenCalledWith({ paths: '/test' })
+    expect(config.env).toEqual({ remoteRefreshPort: 2000 })
+  })
+
+  it('preserves existing env entries', async () => {
+    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    const withRemoteRefresh = plugin()
+
+    const config = withRemoteRefresh({ env: { foo: 'bar' } })
+
+    expect(config.env).toEqual({ foo: 'bar', remoteRefreshPort: 2000 })
+  })
+
+  it('reuses an existing server instance', async () => {
+    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    const withRemoteRefresh = plugin()
+
+    const config1 = withRemoteRefresh()
+    createServer.mockReturnValue({ address: () => ({ port: 2001 }) })
+    const config2 = withRemoteRefresh()
+
+    expect(createServer).toHaveBeenCalledTimes(1)
+    expect(config1.env).toEqual({ remoteRefreshPort: 2000 })
+    expect(config2.env).toEqual({ remoteRefreshPort: 2000 })
+  })
+})


### PR DESCRIPTION
I embarrassingly forgot to add tests for the entrypoint of the library and of course I managed to introduce a regression there.

With this bug fix I've included tests that should bring coverage for all published code up to 100% :)