### PR TITLE
Misc updates

### DIFF
--- a/example/next.config.js
+++ b/example/next.config.js
@@ -1,5 +1,10 @@
+const path = require('path')
+
 const withRemoteRefresh = require('next-remote-refresh')({
-  paths: [require('path').resolve(__dirname, '../package.json')],
+  paths: [
+    path.resolve(__dirname, '../package.json'),
+    path.resolve(__dirname, 'watch'),
+  ],
 })
 
 const nextConfig = {}

--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -1,22 +1,26 @@
-import { useState } from 'react'
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
 import { useRemoteRefresh } from 'next-remote-refresh/hook'
+import { useState } from 'react'
 
-export default function Index({ name, version, description }) {
+export default function Index({ pkg, watchFiles = [] }) {
   const [count, setCount] = useState(0)
   useRemoteRefresh()
   return (
     <div>
       <h2>
-        {name} - v{version}
+        {pkg.name} - v{pkg.version}
       </h2>
-      <p>{description}</p>
+      <p>{pkg.description}</p>
       <div>
         <button onClick={() => setCount(count - 1)}>-</button>
         <button onClick={() => setCount(count + 1)}>+</button>
         <span>{count}</span>
       </div>
+      <h3>Files in <code>watch/</code></h3>
+      <ul>
+        {watchFiles.map(({ fileName, size }) => <li key={fileName}>{fileName} ({size}b)</li>)}
+      </ul>
       <em>
         Hint: Update the package.json file at the root to see it live update.
       </em>
@@ -26,8 +30,12 @@ export default function Index({ name, version, description }) {
 
 export function getStaticProps() {
   return {
-    props: JSON.parse(
-      fs.readFileSync(path.resolve(process.cwd(), '../package.json'), 'utf-8'),
-    ),
+    props: {
+      pkg: JSON.parse(fs.readFileSync('../package.json', 'utf8')),
+      watchFiles: fs.readdirSync('watch').map((fileName) => {
+        const stat = fs.statSync(path.resolve('watch', fileName))
+        return { fileName, size: stat.size }
+      }),
+    },
   }
 }

--- a/example/watch/.gitignore
+++ b/example/watch/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/server.test.js
+++ b/server.test.js
@@ -37,12 +37,12 @@ describe('server', () => {
     try {
       await once(socket, 'open')
 
-      watcherMock.emit('change', '/test/foo.txt')
+      watcherMock.emit('all', 'change', '/test/foo.txt')
 
       const [data] = await once(socket, 'message')
 
       // TODO: server sends `undefined` when a file changes outside of the working directory
-      expect(data.toString('utf8')).toMatch('undefined')
+      expect(data.toString('utf8')).toEqual('/test/foo.txt')
     } finally {
       socket.close()
     }


### PR DESCRIPTION
This PR contains the aforementioned fixes to the paths created by the file watcher. I'm passing `cwd` to chokidar to make it return paths relative to `process.cwd()`. These paths are then sent as-is to any connected clients.

This is a breaking change in that the `basename` of the working directory is no longer prepended - I think this is necessary because the old strategy was incompatible with paths which share no common ancestor with the working directory. It also makes equality checks simpler on the front end (for me at least - in my case I currently have to strip out any leading `../` and check for a match with `.endsWith()`). 