### PR TITLE
Avoid emitting events during the initial directory scan

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ module.exports = function createServer({ paths, ignored }) {
   let sockets = []
 
   const watcher = chokidar
-    .watch(paths, { ignored, cwd: process.cwd() })
+    .watch(paths, { cwd: process.cwd(), ignored, ignoreInitial: true })
     .on('all', (event, filePath) => {
       console.log(`[remote-refresh] ${filePath} updated`)
       sockets.map((socket) => socket.send(filePath))


### PR DESCRIPTION
On server startup, next-remote-refresh logs all of the files matched in the `paths` glob(s) due to chokidar's default behavior of emitting `add`/`addDir` for all of the files it discovers. Setting this configuration to `true` lets us avoid a bunch of unnecessary console spam.