### PR TITLE
Prevent scrolling to the top of the page

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -14,7 +14,7 @@ module.exports.useRemoteRefresh = function ({ shouldRefresh } = {}) {
       const ws = wsRef.current
       const listener = (event) => {
         if (!shouldRefresh || shouldRefresh(event.data)) {
-          router.replace(router.asPath)
+          router.replace(router.asPath, router.asPath, { scroll: false })
         }
       }
       ws.addEventListener('message', listener)


### PR DESCRIPTION
Thanks for making this package, it's super useful!

I noticed that the auto refresh would scroll to the top of the page, so this just makes it stay at the same position.