### PR TITLE
fix: wait for ws server to be initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ const withRemoteRefresh = require('next-remote-refresh')({
   ignored: '**/*.json',
 })
 
-module.exports = withRemoteRefresh(nextConfig)
+module.exports = async () => {
+  const config = await withRemoteRefresh(nextConfig)
+  return config
+}
 ```
 
 ### `useRemoteRefresh` hook

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,4 +6,4 @@ interface PluginOptions {
   signal?: AbortSignal
 }
 
-export default function plugin (options: PluginOptions): (nextConfig: NextConfig) => NextConfig
+export default function plugin (options: PluginOptions): (nextConfig: NextConfig) => Promise<NextConfig>

--- a/index.js
+++ b/index.js
@@ -3,10 +3,16 @@ const createServer = require('./server')
 module.exports = function plugin(options) {
   let port
 
-  return function withConfig(nextConfig = {}) {
+  return async function withConfig(nextConfig = {}) {
     if (process.env.NODE_ENV !== 'production') {
       if (port === undefined) {
-        ({ port } = createServer(options).address())
+        const server = createServer(options)
+        await new Promise((resolve, reject) => {
+          server.on('listening', resolve)
+          server.on('error', reject)
+          server.on('close', reject)
+        });
+        ({ port } = server.address())
       }
 
       if (nextConfig.env === undefined) {

--- a/index.test.js
+++ b/index.test.js
@@ -9,31 +9,51 @@ describe('plugin', () => {
   })
 
   it('sets remoteRefreshPort in the env', async () => {
-    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    createServer.mockReturnValue({
+      address: () => ({ port: 2000 }),
+      on: (event, callback) => {
+        if (event === 'listening') callback()
+      },
+    })
     const withRemoteRefresh = plugin({ paths: '/test' })
 
-    const config = withRemoteRefresh()
+    const config = await withRemoteRefresh()
 
     expect(createServer).toHaveBeenCalledWith({ paths: '/test' })
     expect(config.env).toEqual({ remoteRefreshPort: 2000 })
   })
 
   it('preserves existing env entries', async () => {
-    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    createServer.mockReturnValue({
+      address: () => ({ port: 2000 }),
+      on: (event, callback) => {
+        if (event === 'listening') callback()
+      },
+    })
     const withRemoteRefresh = plugin()
 
-    const config = withRemoteRefresh({ env: { foo: 'bar' } })
+    const config = await withRemoteRefresh({ env: { foo: 'bar' } })
 
     expect(config.env).toEqual({ foo: 'bar', remoteRefreshPort: 2000 })
   })
 
   it('reuses an existing server instance', async () => {
-    createServer.mockReturnValue({ address: () => ({ port: 2000 }) })
+    createServer.mockReturnValue({
+      address: () => ({ port: 2000 }),
+      on: (event, callback) => {
+        if (event === 'listening') callback()
+      },
+    })
     const withRemoteRefresh = plugin()
 
-    const config1 = withRemoteRefresh()
-    createServer.mockReturnValue({ address: () => ({ port: 2001 }) })
-    const config2 = withRemoteRefresh()
+    const config1 = await withRemoteRefresh()
+    createServer.mockReturnValue({
+      address: () => ({ port: 2001 }),
+      on: (event, callback) => {
+        if (event === 'listening') callback()
+      },
+    })
+    const config2 = await withRemoteRefresh()
 
     expect(createServer).toHaveBeenCalledTimes(1)
     expect(config1.env).toEqual({ remoteRefreshPort: 2000 })


### PR DESCRIPTION
closes #29 

I also adapted the "Usage" section of the README to export an async function, as suggested by @ajitid in #29. I think this makes it clear enough that `withRemoteRefresh` is async, the types also represent that.