### PR TITLE
fix port type warning when using multiple next.config plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function plugin(options) {
         nextConfig.env = {}
       }
 
-      nextConfig.env.remoteRefreshPort = port
+      nextConfig.env.remoteRefreshPort = String(port)
     }
 
     return nextConfig


### PR DESCRIPTION
Issue and solution described in #33 .

Coercing the port into a string fixes/removes the warning. Thanks!